### PR TITLE
feature/cmcd-config-object

### DIFF
--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -255,11 +255,9 @@ export class ChunkMetadata {
 //
 // @public (undocumented)
 export type CMCDControllerConfig = {
-    enabled: boolean;
     sessionId?: string;
     contentId?: string;
     useHeaders?: boolean;
-    controller?: typeof CMCDController;
 };
 
 // Warning: (ae-missing-release-tag) "CuesInterface" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -974,6 +972,7 @@ export type HlsConfig = {
     timelineController?: typeof TimelineController;
     emeController?: typeof EMEController;
     cmcd?: CMCDControllerConfig;
+    cmcdController?: typeof CMCDController;
     abrController: typeof AbrController;
     bufferController: typeof BufferController;
     capLevelController: typeof CapLevelController;
@@ -2151,18 +2150,18 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:56:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:165:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
-// src/config.ts:174:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:175:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:177:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:178:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:179:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:181:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:185:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:186:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:187:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:188:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:163:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
+// src/config.ts:172:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:173:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:175:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:176:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:177:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:179:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:182:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:184:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:185:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:186:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:187:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/api-extractor/report/hls.js.api.md
+++ b/api-extractor/report/hls.js.api.md
@@ -255,10 +255,11 @@ export class ChunkMetadata {
 //
 // @public (undocumented)
 export type CMCDControllerConfig = {
-    cmcdEnabled: boolean;
-    cmcdSessionId?: string;
-    cmcdContentId?: string;
-    cmcdUseHeaders?: boolean;
+    enabled: boolean;
+    sessionId?: string;
+    contentId?: string;
+    useHeaders?: boolean;
+    controller?: typeof CMCDController;
 };
 
 // Warning: (ae-missing-release-tag) "CuesInterface" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
@@ -972,14 +973,14 @@ export type HlsConfig = {
     subtitleTrackController?: typeof SubtitleTrackController;
     timelineController?: typeof TimelineController;
     emeController?: typeof EMEController;
-    cmcdController?: typeof CMCDController;
+    cmcd?: CMCDControllerConfig;
     abrController: typeof AbrController;
     bufferController: typeof BufferController;
     capLevelController: typeof CapLevelController;
     fpsController: typeof FPSController;
     progressive: boolean;
     lowLatencyMode: boolean;
-} & ABRControllerConfig & BufferControllerConfig & CapLevelControllerConfig & CMCDControllerConfig & EMEControllerConfig & FPSControllerConfig & FragmentLoaderConfig & LevelControllerConfig & MP4RemuxerConfig & PlaylistLoaderConfig & StreamControllerConfig & LatencyControllerConfig & TimelineControllerConfig & TSDemuxerConfig;
+} & ABRControllerConfig & BufferControllerConfig & CapLevelControllerConfig & EMEControllerConfig & FPSControllerConfig & FragmentLoaderConfig & LevelControllerConfig & MP4RemuxerConfig & PlaylistLoaderConfig & StreamControllerConfig & LatencyControllerConfig & TimelineControllerConfig & TSDemuxerConfig;
 
 // Warning: (ae-missing-release-tag) "HlsEventEmitter" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
 //
@@ -2150,18 +2151,18 @@ export interface UserdataSample {
 
 // Warnings were encountered during analysis:
 //
-// src/config.ts:164:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
-// src/config.ts:173:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:174:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:176:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:177:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:178:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:180:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:182:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:184:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:185:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:186:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
-// src/config.ts:187:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:56:3 - (ae-forgotten-export) The symbol "CMCDController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:165:3 - (ae-forgotten-export) The symbol "ILogger" needs to be exported by the entry point hls.d.ts
+// src/config.ts:174:3 - (ae-forgotten-export) The symbol "AudioStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:175:3 - (ae-forgotten-export) The symbol "AudioTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:177:3 - (ae-forgotten-export) The symbol "SubtitleStreamController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:178:3 - (ae-forgotten-export) The symbol "SubtitleTrackController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:179:3 - (ae-forgotten-export) The symbol "TimelineController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:181:3 - (ae-forgotten-export) The symbol "EMEController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:185:3 - (ae-forgotten-export) The symbol "AbrController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:186:3 - (ae-forgotten-export) The symbol "BufferController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:187:3 - (ae-forgotten-export) The symbol "CapLevelController" needs to be exported by the entry point hls.d.ts
+// src/config.ts:188:3 - (ae-forgotten-export) The symbol "FPSController" needs to be exported by the entry point hls.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -94,10 +94,7 @@
   - [`licenseResponseCallback`](#licenseResponseCallback)
   - [`drmSystemOptions`](#drmSystemOptions)
   - [`requestMediaKeySystemAccessFunc`](#requestMediaKeySystemAccessFunc)
-  - [`cmcdEnabled`](#cmcdEnabled)
-  - [`cmcdSessionId`](#cmcdSessionId)
-  - [`cmcdContentId`](#cmcdContentId)
-  - [`cmcdUseHeaders`](#cmcdUseHeaders)
+  - [`cmcd`](#cmcd)
 - [Video Binding/Unbinding API](#video-bindingunbinding-api)
   - [`hls.attachMedia(videoElement)`](#hlsattachmediavideoelement)
   - [`hls.detachMedia()`](#hlsdetachmedia)
@@ -395,10 +392,7 @@ var config = {
   licenseXhrSetup: undefined,
   drmSystemOptions: {},
   requestMediaKeySystemAccessFunc: requestMediaKeySystemAccess,
-  cmcdEnabled: false,
-  cmcdSessionId: undefined,
-  cmcdContentId: undefined,
-  cmcdUseHeaders: false,
+  cmcd: undefined,
 };
 
 var hls = new Hls(config);
@@ -1200,22 +1194,14 @@ With the default argument, `''` will be specified for each option (_i.e. no spec
 
 Allows for the customization of `window.navigator.requestMediaKeySystemAccess`.
 
-### `cmcdEnabled`
+### `cmcd`
 
-Enabled the passing of [Common Media Client Data (CMCD)](https://cdn.cta.tech/cta/media/media/resources/standards/pdfs/cta-5004-final.pdf)
-on all media requests (manifests, playlists, a/v segments, timed text).
+When the `cmcd` object is defined, [Common Media Client Data (CMCD)](https://cdn.cta.tech/cta/media/media/resources/standards/pdfs/cta-5004-final.pdf)
+data will be passed on all media requests (manifests, playlists, a/v segments, timed text). It's configuration values are:
 
-### `cmcdSession`
-
-The CMCD session id. One will be automatically generated if none is provided.
-
-### `cmcdContent`
-
-The CMCD content id.
-
-### `cmcdUseHeaders`
-
-Send CMCD data in request headers instead of as query args.
+- `sessionId`: The CMCD session id. One will be automatically generated if none is provided.
+- `contentId`: The CMCD content id.
+- `useHeaders`: Send CMCD data in request headers instead of as query args. Defaults to `false`.
 
 ## Video Binding/Unbinding API
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -49,10 +49,9 @@ export type CapLevelControllerConfig = {
 };
 
 export type CMCDControllerConfig = {
-  cmcdEnabled: boolean;
-  cmcdSessionId?: string;
-  cmcdContentId?: string;
-  cmcdUseHeaders?: boolean;
+  sessionId?: string;
+  contentId?: string;
+  useHeaders?: boolean;
 };
 
 export type DRMSystemOptions = {
@@ -179,6 +178,7 @@ export type HlsConfig = {
   // EME
   emeController?: typeof EMEController;
   // CMCD
+  cmcd?: CMCDControllerConfig;
   cmcdController?: typeof CMCDController;
 
   abrController: typeof AbrController;
@@ -190,7 +190,6 @@ export type HlsConfig = {
 } & ABRControllerConfig &
   BufferControllerConfig &
   CapLevelControllerConfig &
-  CMCDControllerConfig &
   EMEControllerConfig &
   FPSControllerConfig &
   FragmentLoaderConfig &
@@ -280,10 +279,7 @@ export const hlsDefaultConfig: HlsConfig = {
   testBandwidth: true,
   progressive: false,
   lowLatencyMode: true,
-  cmcdEnabled: false,
-  cmcdSessionId: undefined,
-  cmcdContentId: undefined,
-  cmcdUseHeaders: false,
+  cmcd: undefined,
 
   // Dynamic Modules
   ...timelineConfig(),

--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -34,6 +34,8 @@ export default class CMCDController implements ComponentAPI {
   private config: HlsConfig;
   private media?: HTMLMediaElement;
   private sid?: string;
+  private cid?: string;
+  private useHeaders: boolean = false;
   private initialized: boolean = false;
   private starved: boolean = false;
   private buffering: boolean = true;
@@ -43,12 +45,15 @@ export default class CMCDController implements ComponentAPI {
   constructor(hls: Hls) {
     this.hls = hls;
     const config = (this.config = hls.config);
+    const { cmcd } = config;
 
-    if (config.cmcdEnabled === true) {
+    if (cmcd != null) {
       config.pLoader = this.createPlaylistLoader();
       config.fLoader = this.createFragmentLoader();
 
-      this.sid = config.cmcdSessionId || CMCDController.uuid();
+      this.sid = cmcd.sessionId || CMCDController.uuid();
+      this.cid = cmcd.contentId;
+      this.useHeaders = cmcd.useHeaders === true;
       this.registerListeners();
     }
   }
@@ -129,7 +134,7 @@ export default class CMCDController implements ComponentAPI {
       v: CMCDVersion,
       sf: CMCDStreamingFormat.HLS,
       sid: this.sid,
-      cid: this.config.cmcdContentId,
+      cid: this.cid,
       pr: this.media?.playbackRate,
       mtp: this.hls.bandwidthEstimate / 1000,
     };
@@ -159,7 +164,7 @@ export default class CMCDController implements ComponentAPI {
 
     // TODO: Implement rtp, nrr, nor, dl
 
-    if (this.config.cmcdUseHeaders) {
+    if (this.useHeaders) {
       const headers = CMCDController.toHeaders(data);
       if (!Object.keys(headers).length) {
         return;

--- a/src/controller/cmcd-controller.ts
+++ b/src/controller/cmcd-controller.ts
@@ -34,6 +34,8 @@ export default class CMCDController implements ComponentAPI {
   private config: HlsConfig;
   private media?: HTMLMediaElement;
   private sid?: string;
+  private cid?: string;
+  private useHeaders: boolean = false;
   private initialized: boolean = false;
   private starved: boolean = false;
   private buffering: boolean = true;
@@ -43,12 +45,15 @@ export default class CMCDController implements ComponentAPI {
   constructor(hls: Hls) {
     this.hls = hls;
     const config = (this.config = hls.config);
+    const { cmcd } = config;
 
-    if (config.cmcdEnabled === true) {
+    if (cmcd != null) {
       config.pLoader = this.createPlaylistLoader();
       config.fLoader = this.createFragmentLoader();
 
-      this.sid = config.cmcdSessionId || CMCDController.uuid();
+      this.sid = cmcd.sessionId || CMCDController.uuid();
+      this.cid = cmcd.contentId;
+      this.useHeaders = cmcd.useHeaders === true;
       this.registerListeners();
     }
   }
@@ -129,7 +134,7 @@ export default class CMCDController implements ComponentAPI {
       v: CMCDVersion,
       sf: CMCDStreamingFormat.HLS,
       sid: this.sid,
-      cid: this.config.cmcdContentId,
+      cid: this.cid,
       pr: this.media?.playbackRate,
       mtp: this.hls.bandwidthEstimate / 1000,
     };
@@ -138,11 +143,7 @@ export default class CMCDController implements ComponentAPI {
   /**
    * Apply CMCD data to a request.
    */
-  private apply(
-    context: LoaderContext,
-    data: CMCD = {},
-    useHeaders = this.config.cmcdUseHeaders
-  ) {
+  private apply(context: LoaderContext, data: CMCD = {}) {
     // apply baseline data
     Object.assign(data, this.createData());
 
@@ -163,7 +164,7 @@ export default class CMCDController implements ComponentAPI {
 
     // TODO: Implement rtp, nrr, nor, dl
 
-    if (useHeaders) {
+    if (this.useHeaders) {
       const headers = CMCDController.toHeaders(data);
       if (!Object.keys(headers).length) {
         return;

--- a/tests/unit/controller/cmcd-controller.ts
+++ b/tests/unit/controller/cmcd-controller.ts
@@ -29,8 +29,8 @@ const data = {
   'com.test-token': Symbol('s'),
 };
 
-const setupEach = function (config?: CMCDControllerConfig) {
-  cmcdController = new CMCDController(new HlsMock(config));
+const setupEach = function (cmcd?: CMCDControllerConfig) {
+  cmcdController = new CMCDController(new HlsMock({ cmcd }));
 };
 
 describe('CMCDController', function () {
@@ -95,14 +95,13 @@ describe('CMCDController', function () {
       it('does not modify requests when disabled', function () {
         setupEach();
 
-        expect(cmcdController.hls.config.pLoader).to.equal(undefined);
-        expect(cmcdController.hls.config.fLoader).to.equal(undefined);
+        const { config } = cmcdController.hls;
+        expect(config.pLoader).to.equal(undefined);
+        expect(config.fLoader).to.equal(undefined);
       });
 
       it('generates a session id if not provided', function () {
-        setupEach({
-          cmcdEnabled: true,
-        });
+        setupEach({});
 
         const c = Object.assign({ frag: {} }, context);
 


### PR DESCRIPTION
Convert the flattened CMCD config properties into a single object.