### PR TITLE
issue/258-xbox-cc

### DIFF
--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -178,6 +178,10 @@ export class SubtitleStreamController
   // display in VOD up to the point where they were enabled mid-stream. 
   // https://github.com/cbsinteractive/avia-player-support/issues/246
   onMediaSeeking() {
+    // Only applies to Xbox platform
+    if (/Xbox; Xbox One/.test(navigator.userAgent)) {
+      return;
+    }
 
     // Find the currently showing subtitle track
     const tracks = Array.from<TextTrack>(this.media.textTracks);
@@ -194,17 +198,15 @@ export class SubtitleStreamController
       // Clear internal buffered lists
       this.tracksBuffered.forEach((_, index, tracks) => tracks[index] = []);
 
-      // This is for Xbox only to address persistent cue issue for Pluto.
-      // Without it, last timed text cue before the seek is called remains 
+      // This is to address persistent cue issue for Pluto. Without it,
+      // the very last timed text cue before the seek is called remains 
       // on the screen even after seek is completed. See ticket below: 
       // https://github.com/cbsinteractive/avia-player-support/issues/258
-      if (/Xbox; Xbox One/.test(navigator.userAgent)) {
-        if (track.mode === 'showing') { 
-          track.mode = 'hidden';
-          self.setTimeout(() => {
-              track.mode = 'showing';
-          }, 10);
-        }
+      if (track.mode === 'showing') { 
+        track.mode = 'hidden';
+        self.setTimeout(() => {
+            track.mode = 'showing';
+        }, 10);
       }
     }
 

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -173,8 +173,12 @@ export class SubtitleStreamController
       );
     }
   }
-
+  
+  // This is needed to correct the Xbox issue. The one where CC doesn't 
+  // display in VOD up to the point where they were enabled mid-stream. 
+  // https://github.com/cbsinteractive/avia-player-support/issues/246
   onMediaSeeking() {
+
     // Find the currently showing subtitle track
     const tracks = Array.from<TextTrack>(this.media.textTracks);
     const track = tracks.find(track => track.mode != 'disabled' && (track.kind == 'subtitles' || track.kind == 'captions'));
@@ -190,11 +194,17 @@ export class SubtitleStreamController
       // Clear internal buffered lists
       this.tracksBuffered.forEach((_, index, tracks) => tracks[index] = []);
 
-      if (track.mode === 'showing') { 
-        track.mode = 'hidden';
-        setTimeout(() => {
-            track.mode = 'showing';
-        }, 10);
+      // This is for Xbox only to address persistent cue issue for Pluto.
+      // Without it, last timed text cue before the seek is called remains 
+      // on the screen even after seek is completed. See ticket below: 
+      // https://github.com/cbsinteractive/avia-player-support/issues/258
+      if (/Xbox; Xbox One/.test(navigator.userAgent)) {
+        if (track.mode === 'showing') { 
+          track.mode = 'hidden';
+          setTimeout(() => {
+              track.mode = 'showing';
+          }, 10);
+        }
       }
     }
 

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -179,7 +179,7 @@ export class SubtitleStreamController
   // https://github.com/cbsinteractive/avia-player-support/issues/246
   onMediaSeeking() {
     // Only applies to Xbox platform
-    if (/Xbox; Xbox One/.test(navigator.userAgent)) {
+    if (!/Xbox; Xbox One/.test(navigator.userAgent)) {
       return;
     }
 

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -189,6 +189,13 @@ export class SubtitleStreamController
 
       // Clear internal buffered lists
       this.tracksBuffered.forEach((_, index, tracks) => tracks[index] = []);
+
+      if (track.mode === 'showing') { 
+        track.mode = 'hidden';
+        setTimeout(() => {
+            track.mode = 'showing';
+        }, 10);
+      }
     }
 
     this.fragPrevious = null;

--- a/src/controller/subtitle-stream-controller.ts
+++ b/src/controller/subtitle-stream-controller.ts
@@ -201,7 +201,7 @@ export class SubtitleStreamController
       if (/Xbox; Xbox One/.test(navigator.userAgent)) {
         if (track.mode === 'showing') { 
           track.mode = 'hidden';
-          setTimeout(() => {
+          self.setTimeout(() => {
               track.mode = 'showing';
           }, 10);
         }


### PR DESCRIPTION
Pluto filed a [new ticket](https://github.com/cbsinteractive/avia-player-support/issues/258) for HLSjs closed captions on Xbox. They are claiming that if you turn on CC midstream, and while the cue is displayed on the screen if you seek back to time 0, that cue remains on the screen until next conversation. 

To resolve the issue, adjusted existing hack a little by toggling `track.mode` from **hidden** to **showing**. This corrects the issue described in the ticket. I can't think any other elegant solution to this problem. If you have better ideas, please let me know. 